### PR TITLE
Make info endpoints produce data in JSON format

### DIFF
--- a/lib/sparql_client/workload_info.ex
+++ b/lib/sparql_client/workload_info.ex
@@ -10,7 +10,8 @@ defmodule SparqlClient.WorkloadInfo do
             last_interval_failure_count: 0,
             last_interval_success_count: 0,
             database_failure_load: 0,
-            last_finished_workload: nil
+            last_finished_workload: nil,
+            start_time: DateTime.utc_now()
 
   use Accessible
 
@@ -80,7 +81,8 @@ defmodule SparqlClient.WorkloadInfo do
           last_interval_failure_count: integer,
           last_interval_success_count: integer,
           database_failure_load: float,
-          last_finished_workload: %Workload{last_finished_workload: nil} | nil
+          last_finished_workload: %Workload{last_finished_workload: nil} | nil,
+          start_time: DateTime.t()
         }
 
   @type query_types :: SparqlClient.query_types()
@@ -226,7 +228,8 @@ defmodule SparqlClient.WorkloadInfo do
         recovery_mode: new_recovery_mode,
         last_interval_success_count: 0,
         last_interval_failure_count: 0,
-        last_finished_workload: %{last_finished_workload | last_finished_workload: nil}
+        last_finished_workload: %{last_finished_workload | last_finished_workload: nil},
+        start_time: DateTime.utc_now()
     }
 
     {:noreply, new_workload}

--- a/lib/sparql_client/workload_info.ex
+++ b/lib/sparql_client/workload_info.ex
@@ -9,7 +9,8 @@ defmodule SparqlClient.WorkloadInfo do
             recovery_mode: false,
             last_interval_failure_count: 0,
             last_interval_success_count: 0,
-            database_failure_load: 0
+            database_failure_load: 0,
+            last_finished_workload: nil
 
   use Accessible
 
@@ -78,7 +79,8 @@ defmodule SparqlClient.WorkloadInfo do
           recovery_mode: boolean,
           last_interval_failure_count: integer,
           last_interval_success_count: integer,
-          database_failure_load: float
+          database_failure_load: float,
+          last_finished_workload: %Workload{last_finished_workload: nil} | nil
         }
 
   @type query_types :: SparqlClient.query_types()
@@ -182,6 +184,8 @@ defmodule SparqlClient.WorkloadInfo do
   end
 
   def handle_cast(:clocktick, %Workload{} = workload) do
+    last_finished_workload = workload
+
     old_failure_factor = workload.database_failure_load * @previous_interval_keep_factor
 
     new_failure_factor =
@@ -221,7 +225,8 @@ defmodule SparqlClient.WorkloadInfo do
       | database_failure_load: new_failure_load,
         recovery_mode: new_recovery_mode,
         last_interval_success_count: 0,
-        last_interval_failure_count: 0
+        last_interval_failure_count: 0,
+        last_finished_workload: %{last_finished_workload | last_finished_workload: nil}
     }
 
     {:noreply, new_workload}

--- a/lib/sparql_server/router.ex
+++ b/lib/sparql_server/router.ex
@@ -51,7 +51,10 @@ defmodule SparqlServer.Router do
     IO.inspect(running_queries, [{:label, "Currently running queries"} | inspect_options])
 
     json = running_queries |> Enum.map(fn (q) -> %{ type: "queries", id: q.id, attributes: q } end)
-    send_resp(conn, 200, Poison.encode!(%{ data: json }))
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Poison.encode!(%{ data: json }))
   end
 
   get "/processing-queries" do
@@ -61,7 +64,10 @@ defmodule SparqlServer.Router do
     IO.inspect(processing_queries, [{:label, "Currently processing queries"} | inspect_options])
 
     json = processing_queries |> Enum.map(fn (q) -> %{ type: "queries", id: q.id, attributes: q } end)
-    send_resp(conn, 200, Poison.encode!(%{ data: json }))
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Poison.encode!(%{ data: json }))
   end
 
   get "/recovery-status" do
@@ -74,7 +80,9 @@ defmodule SparqlServer.Router do
 
     IO.inspect(last_completed_workload_info, [{:label, "Current recovery status"} | inspect_options])
 
-    send_resp(conn, 200, Poison.encode!(last_completed_workload_info))
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Poison.encode!(last_completed_workload_info))
   end
 
   match(_, do: send_resp(conn, 404, "404 error not found"))

--- a/lib/sparql_server/router.ex
+++ b/lib/sparql_server/router.ex
@@ -7,6 +7,7 @@ defmodule SparqlServer.Router do
   use Plug.Router
   require Logger
   require ALog
+  require Poison
 
   alias SparqlClient.InfoEndpoint
 
@@ -49,7 +50,8 @@ defmodule SparqlServer.Router do
 
     IO.inspect(running_queries, [{:label, "Currently running queries"} | inspect_options])
 
-    send_resp(conn, 200, inspect(running_queries, inspect_options))
+    json = running_queries |> Enum.map(fn (q) -> %{ type: "queries", id: q.id, attributes: q } end)
+    send_resp(conn, 200, Poison.encode!(%{ data: json }))
   end
 
   get "/processing-queries" do
@@ -58,7 +60,8 @@ defmodule SparqlServer.Router do
 
     IO.inspect(processing_queries, [{:label, "Currently processing queries"} | inspect_options])
 
-    send_resp(conn, 200, inspect(processing_queries, inspect_options))
+    json = processing_queries |> Enum.map(fn (q) -> %{ type: "queries", id: q.id, attributes: q } end)
+    send_resp(conn, 200, Poison.encode!(%{ data: json }))
   end
 
   get "/recovery-status" do
@@ -67,7 +70,7 @@ defmodule SparqlServer.Router do
 
     IO.inspect(state, [{:label, "Current recovery status"} | inspect_options])
 
-    send_resp(conn, 200, inspect(state, inspect_options))
+    send_resp(conn, 200, Poison.encode!(state))
   end
 
   match(_, do: send_resp(conn, 404, "404 error not found"))

--- a/lib/sparql_server/router.ex
+++ b/lib/sparql_server/router.ex
@@ -65,12 +65,16 @@ defmodule SparqlServer.Router do
   end
 
   get "/recovery-status" do
-    state = SparqlClient.WorkloadInfo.get_state()
+    last_completed_workload_info =
+      SparqlClient.WorkloadInfo.get_state()
+      |> Map.get(:last_finished_workload)
+      |> Map.update!(:start_time, &DateTime.to_iso8601/1)
+
     inspect_options = [limit: 100_000, pretty: true, width: 180]
 
-    IO.inspect(state, [{:label, "Current recovery status"} | inspect_options])
+    IO.inspect(last_completed_workload_info, [{:label, "Current recovery status"} | inspect_options])
 
-    send_resp(conn, 200, Poison.encode!(state))
+    send_resp(conn, 200, Poison.encode!(last_completed_workload_info))
   end
 
   match(_, do: send_resp(conn, 404, "404 error not found"))


### PR DESCRIPTION
Convert the data format to JSON to make the information produced
by the info endpoints easier to consume by other applications.
Following endpoints are modified:
- /recovery-status
- /processing-queries
- /running-queries