### PR TITLE
WIP: Feature/indexed deltas, attach index to delta messages to indicate order

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Flags which can be either on or off translate the environment variable string to
 - `INSPECT_OUTGOING_SPARQL_QUERY_RESPONSES` : Inspects the responses coming back from the backing triplestore
 - `LOG_OUTGOING_SPARQL_QUERY_ROUNDTRIP` : Logs both the request and the response to/from the backing triplestore closely together in the logs
 - `LOG_WORKLOAD_INFO_REQUESTS` : Logs workload information to the console when it is requested through an http call
+- `DELTA_CACHE_TIMEOUT` : Specifies how long the delta messages should be coalesced
 
 ### Query timeout configuration
 Complex SPARQL queries can take a long time to process and execute. The time mu-authorization is allowed to spend on this processing and execution before timing out can be configured through the following environment variables:

--- a/config/config.exs
+++ b/config/config.exs
@@ -87,13 +87,13 @@ config :"mu-authorization",
 #     config :logger, level: :info
 #
 
+config :logger,
+  compile_time_purge_matching: :debug,
+  level: :warn
+
 # config :logger,
 #   compile_time_purge_level: :debug,
-#   level: :info
-
-config :logger,
-  compile_time_purge_level: :debug,
-  level: :warn
+#   level: :warn
 
 if Mix.env() == :test do
   config :junit_formatter,

--- a/config/config.exs
+++ b/config/config.exs
@@ -53,6 +53,7 @@ end
 #     config :sparqlex, key: :value
 config :"mu-authorization",
   author: :"mu-semtech",
+  delta_cache_timeout: CH.system_number("DELTA_CACHE_TIMEOUT", 500),
   log_server_configuration: CH.system_boolean("LOG_SERVER_CONFIGURATION"),
   log_outgoing_sparql_queries: CH.system_boolean("LOG_OUTGOING_SPARQL_QUERIES"),
   log_incoming_sparql_queries: CH.system_boolean("LOG_INCOMING_SPARQL_QUERIES"),
@@ -88,7 +89,7 @@ config :"mu-authorization",
 #
 
 config :logger,
-  compile_time_purge_matching: :debug,
+  compile_time_purge_level: :debug,
   level: :warn
 
 # config :logger,

--- a/lib/delta/cache.ex
+++ b/lib/delta/cache.ex
@@ -1,0 +1,80 @@
+defmodule Delta.Cache do
+  use GenServer
+
+  @coalesce_time 2 * 1000
+
+  def inform(delta, mu_call_id_trail) do
+      GenServer.call( __MODULE__, {:inform, delta, mu_call_id_trail})
+  end
+
+
+  def flush(mu_call_id_trail) do
+    GenServer.cast( __MODULE__, {:flush, mu_call_id_trail})
+  end
+
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+
+  @impl true
+  def init(_) do
+    {:ok, %{}}
+  end
+
+
+  defp touch_timeout(state, mu_call_id_trail) do
+    ref = Process.send_after(self(), {:timeout, mu_call_id_trail}, @coalesce_time)
+    new_state = Map.update(state, mu_call_id_trail, %{buffer: [], ref: ref}, fn x ->
+      Process.cancel_timer(x.ref)
+      # Keep buffer intact
+      %{x | ref: ref}
+    end)
+
+    new_state
+  end
+
+
+  defp do_flush(state, mu_call_id_trail) do
+    # Remove possible timeout things
+    {cache, new_state} = Map.pop(state, mu_call_id_trail)
+
+    Process.cancel_timer(cache.ref)
+
+    json_model = %{
+      "changeSets" => cache.buffer
+    }
+
+    json_model
+    |> IO.inspect(label: "hallooooo")
+    |> Poison.encode!()
+    |> Delta.Messenger.inform_clients(mu_call_id_trail: mu_call_id_trail)
+
+    new_state
+  end
+
+
+  # TODO: this message might be incorrect, cause it was already in queue, after a touch message
+  @impl true
+  def handle_info({:timeout, trail}, state) do
+    new_state = do_flush(state, trail)
+
+    {:noreply, new_state}
+  end
+
+
+  @impl true
+  def handle_cast({:flush, trail}, state) do
+    {:noreply, do_flush(state, trail)}
+  end
+
+
+  @impl true
+  def handle_call({:inform, delta, trail}, _from, state) do
+    new_state = touch_timeout(state, trail)
+    |> update_in([trail, :buffer], &(&1 ++ delta))
+
+    {:reply, :ok, new_state}
+  end
+end

--- a/lib/delta/delta.ex
+++ b/lib/delta/delta.ex
@@ -46,7 +46,8 @@ defmodule Delta do
     delta
     |> Delta.Message.construct(authorization_groups, origin)
     |> Logging.EnvLog.inspect(:log_delta_messages, label: "Constructed body for clients")
-    |> Delta.Messenger.inform_clients(mu_call_id_trail: mu_call_id_trail)
+    |> Delta.Cache.inform(mu_call_id_trail)
+    # |> Delta.Messenger.inform_clients(mu_call_id_trail: mu_call_id_trail)
 
     delta
   end

--- a/lib/graph_reasoner/support/term_selectors.ex
+++ b/lib/graph_reasoner/support/term_selectors.ex
@@ -1,5 +1,4 @@
-defmodule TermSelectors do
-  alias GraphReasoner.Support.TermSelectors
+defmodule GraphReasoner.Support.TermSelectors do
   alias InterpreterTerms.SymbolMatch, as: Sym
   alias InterpreterTerms.WordMatch, as: Word
 

--- a/lib/graph_reasoner/type_reasoner/type_reasoner.ex
+++ b/lib/graph_reasoner/type_reasoner/type_reasoner.ex
@@ -1,6 +1,6 @@
-defmodule TypeReasoner do
+defmodule GraphReasoner.TypeReasoner do
+  alias GraphReasoner.{ModelInfo, QueryInfo}
   alias Updates.QueryAnalyzer.Iri
-  alias GraphReasoner.{TypeReasoner, ModelInfo, QueryInfo}
 
   @moduledoc """
   The TypeReasoner derives types for known entities and pushes the

--- a/lib/sparql_server/sparql_server.ex
+++ b/lib/sparql_server/sparql_server.ex
@@ -65,6 +65,7 @@ defmodule SparqlServer do
 
     children = [
       {Cache.Types, %{}},
+      {Delta.Message, nil},
       {Support.Id, nil},
       {SparqlClient.InfoEndpoint, nil},
       {SparqlClient.WorkloadInfo, nil},

--- a/lib/sparql_server/sparql_server.ex
+++ b/lib/sparql_server/sparql_server.ex
@@ -72,7 +72,7 @@ defmodule SparqlServer do
       {Interpreter.CachedInterpreter, nil},
       {Interpreter.Diff.Store.Storage, nil},
       {Interpreter.Diff.Store.Manipulator, nil},
-      {Plug.Adapters.Cowboy2,
+      {Plug.Cowboy,
        scheme: :http, plug: SparqlServer.Router, options: [port: port]},
       :poolboy.child_spec(:worker, [
         {:name, {:local, :query_worker}},

--- a/lib/sparql_server/sparql_server.ex
+++ b/lib/sparql_server/sparql_server.ex
@@ -65,6 +65,7 @@ defmodule SparqlServer do
 
     children = [
       {Cache.Types, %{}},
+      {Delta.Cache, nil},
       {Delta.Message, nil},
       {Support.Id, nil},
       {SparqlClient.InfoEndpoint, nil},


### PR DESCRIPTION
Extend delta message format to:
```
{
  "changeset": {
    "allowed_groups": ... ,
    "origin": ... ,
    "insert": [].
    "index": number
  },
}
```
The index is initialized from epoch in milliseconds and incremented with every delta message.
This way all delta messages are indexed monotonically increasing.